### PR TITLE
Fix mobile search alignment and update breakpoints

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,7 +107,7 @@ p {
     display: none;
 }
 
-@media screen and (min-width: 650px) {
+@media screen and (min-width: 750px) {
     .topmenu ul {
         display: block;
     }
@@ -140,6 +140,16 @@ p {
     }
 }
 
+/* --- Responsive Menu ---*/
+@media screen and (max-width: 992px) {
+    #responsive-menu-container .responsive-menu-search-box {
+    width: 100%;
+    padding: 0 2%;
+    border-radius: 2px;
+    height: 30px;
+    -webkit-appearance: none;
+    }
+}
 
 /* --- Begin Top Footer ---*/
 footer {


### PR DESCRIPTION
If this commit successfully merges, more than likely we will need to also update the breakpoint in the actual Responsive Menu plugin itself. 

Dashboard>Responsive Menu>Initial Setup>Breakpoint>Change to 750px instead of 992px
